### PR TITLE
feat: Update go version to 1.24.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/andrew-field/projecteuler-go
 
-go 1.24.0
+go 1.24.1
 
 require github.com/andrew-field/maths/v2 v2.2.0


### PR DESCRIPTION
- Auto-generated by [bump-go-mod-version][1] Github action.

[1]: https://github.com/andrew-field/reusable-workflows/actions/workflows/bump-go-mod-version.yml