### PR TITLE
feat: update go bump frequency

### DIFF
--- a/.github/workflows/bump-go-mod-version.yml
+++ b/.github/workflows/bump-go-mod-version.yml
@@ -2,7 +2,7 @@ name: Bump go mod version
 
 on:
   schedule:
-    - cron: "40 0 1 * *"
+    - cron: "40 0 */7 * *"
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:


### PR DESCRIPTION
Update go bump workflow to run every 7 days (mostly).